### PR TITLE
corrige: expect no teste - deve criar novo usuario

### DIFF
--- a/src/__tests__/users.spec.js
+++ b/src/__tests__/users.spec.js
@@ -11,7 +11,8 @@ describe('Users', () => {
         name: 'John Doe',
         username: 'johndoe'
       })
-    expect(201);
+    
+    expect(response.status).toEqual(201);
 
     expect(validate(response.body.id)).toBe(true);
 


### PR DESCRIPTION
O primeiro expect do teste de criar novo usuário está com falso positivo, qualquer status que passar para ele retorna como verdadeiro.